### PR TITLE
Disentangles the reading of YAML files from the Configuration object

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # YAECS (Yet Another Experiment Config System)
 
-[![Offial repo](https://img.shields.io/badge/official%20repo-YAECS-%23ff9626?logo=gitlab)](https://gitlab.com/reactivereality/public/yaecs)
 [![License](https://img.shields.io/badge/license-LGPLV3%2B-%23c4c2c2)](https://www.gnu.org/licenses/)
 
 ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/valentingol/yaecs/main)
@@ -23,7 +22,7 @@ highly desirable properties such that **maintenance-less forward-compatibility**
 reproducibility** of any experiment, and **extreme clarity** of former experiments for your future self or
 collaborators.
 
-[LINK TO DOCUMENTATION](https://gitlab.com/reactivereality/public/yaecs/-/wikis/home)
+[LINK TO DOCUMENTATION](https://github.com/valentingol/yaecs/blob/main/DOCUMENTATION_WIP.md)
 
 ## Installation
 

--- a/short-readme.md
+++ b/short-readme.md
@@ -1,6 +1,5 @@
 # YAECS (Yet Another Experiment Config System)
 
-[![Offial repo](https://img.shields.io/badge/official%20repo-YAECS-%23ff9626?logo=gitlab)](https://gitlab.com/reactivereality/public/yaecs)
 ![GitHub last commit (branch)](https://img.shields.io/github/last-commit/valentingol/yaecs/main)
 [![License](https://img.shields.io/badge/license-LGPLV3%2B-%23c4c2c2)](https://www.gnu.org/licenses/)
 
@@ -9,16 +8,7 @@
 This package is a Config System which allows easy manipulation of config files
 for safe, clear and repeatable experiments.
 
-**DISCLAIMER:** This repository is the public version of a repository that is
-the property of [Reactive Reality](https://www.reactivereality.com/). This
-repository IS NOT OFFICIAL and might not be maintained in the future. Some
-minor changes* are applied from the
-[official repository (GitLab)](https://gitlab.com/reactivereality/public/yaecs)
-(under lesser GNU license).
-
-*documentation and other PyPI related changes
-
-[LINK TO DOCUMENTATION](https://gitlab.com/reactivereality/public/yaecs/-/wikis/home)
+[LINK TO DOCUMENTATION](https://github.com/valentingol/yaecs/blob/main/DOCUMENTATION_WIP.md)
 
 ## Installation
 
@@ -40,43 +30,27 @@ learning_rate: 0.01
 
 Those will be the default values for those three parameters, so we will keep
 them in the file `my_project/configs/default.yaml`. Then, we just need to
-subclass the Configuration class in this package so your project-specific
-subclass knows where to find the default values for your project. A minimal
-project-specific subclass looks like:
-
-```python
-from yaecs import Configuration
-
-class ProjectSpecific(Configuration):
-    @staticmethod
-    def get_default_config_path():
-        return "./configs/default.yaml"
-
-    def parameters_pre_processing(self):
-        return {}
-```
-
-That's all there is to it! Now if we use
-`config = ProjectSpecific.load_config()`, we can then call `config.data_path`
-or `config.learning_rate` to get their values as defined in the default config.
-We don't need to specify where to get the default config because a project
-should only ever have one default config, which centralises all the parameters
-in that project. Since the location of the default config is a project
-constant, it is defined in your project-specific subclass and there is no
-need to clutter your main code with it. Now, for example, your main.py could
+read the config in the code using `yaecs.make_config`. That's all there is to 
+it: `config = yaecs.make_config("my_project/configs/default.yaml")`, 
+we can then call `config.data_path` or `config.learning_rate` to get their 
+values as defined in the default config. Now, for example, your main.py could
 look like:
 
 ```python
-from project_config import ProjectSpecific
+from yaecs import make_config
 
 if __name__ == "__main__":
-    config = ProjectSpecific.load_config()
+    config = make_config("my_project/configs/default.yaml")
     print(config.details())
 ```
 
 Then, calling `python main.py --learning_rate=0.001` would parse
 the command line and find the pre-existing parameter learning_rate, then change
 its value to 0.001.
+
+Many, many more features are available in YAECS ! But even with just this, you 
+should be ready to start configuring your experiments. Check out the documentation
+for more when you need it !
 
 ## Contribution
 

--- a/unittests/config/conftest.py
+++ b/unittests/config/conftest.py
@@ -150,7 +150,7 @@ def yaml_craziest_config(tmpdir):
     with open(tmpdir / 'e_second.yaml', "w", encoding='utf-8') as fil:
         fil.write("--- !c3\n"
                   "'*.p*': 8\n"
-                  "'*p4': {b: 5}")
+                  "'*p4': !type:dict {b: 5}")
     yield str(tmpdir / 'd_first.yaml'), str(tmpdir / 'e_first.yaml')
 
 
@@ -264,7 +264,7 @@ def config_vs_dict_checks(tmpdir):
                "        key1: 0\n"
                "      key2: ['!type:dict']\n"
                "--- !config10.config11\n"
-               "config1.config7: !main_2\n"
+               "config1.config7:\n"
                "  config8:\n"
                "    param1: !type:dict\n"
                "      key1: !type:dict\n"

--- a/unittests/config/test_config.py
+++ b/unittests/config/test_config.py
@@ -682,7 +682,7 @@ def test_config_vs_dict_checks(caplog, config_vs_dict_checks):
     with caplog.at_level(logging.WARNING):
         logging.getLogger("yaecs").propagate = True
         config = load_config(default_config=config_vs_dict_checks)
-    assert caplog.text.count("WARNING") == 2
+    assert caplog.text.count("WARNING") == 0
     string = f"\nMAIN CONFIG :\nConfiguration hierarchy :\n> {config_vs_dict_checks}" \
              "\n\n - config1 : \n	CONFIG1 CONFIG :\n	 - config2 : \n		CONFIG2 CONFIG :\n" \
              "		 - param1 : {'key1': {'key2': 0}, 'key3': ['!type:dict']}\n\n\n - config3 : \n	CONFIG3 CONFIG :" \
@@ -800,9 +800,6 @@ def test_errors(caplog, yaml_default_unlinked, yaml_default_sub_variations,
                 Exception, match=".*character is not authorised "
                                  "in the default config.*"):
             _ = make_config({"param*": 1})
-        with pytest.raises(Exception, match=".*Unlinked sub-configs are not "
-                                            "allowed.*"):
-            _ = make_config(yaml_default_unlinked)
     assert caplog.text.count("ERROR while pre-processing param") == 4
     with pytest.raises(
             Exception, match=".*Please declare all your variations "

--- a/unittests/experiment/test_project_config/experiments/variations.yaml
+++ b/unittests/experiment/test_project_config/experiments/variations.yaml
@@ -1,6 +1,6 @@
 d: v
 
-f:
+f: !type:dict
   var_1:
     a_config.ts.t4.use: false
     mode: training

--- a/unittests/experiment/utils.py
+++ b/unittests/experiment/utils.py
@@ -8,11 +8,8 @@ Purpose : description""",
 - /home/vac/Documents/Projects/ait-yaecs/unittests/experiment/test_project_config/defaults/default.yaml
 - unittests/experiment/test_project_config/experiments/s
 - unittests/experiment/test_project_config/experiments/variations
-- a_config:
-    ts:
-      t4:
-        fr: b
-        use: true
+- a_config.ts.t4.fr: b
+  a_config.ts.t4.use: true
   mode: validation
 """,
     "config": """a: false
@@ -20,19 +17,13 @@ b: tmp/normal/test
 c: Try something
 d: v
 e: 1
-f:
-  var_1:
-    a_config:
-      ts:
-        t4:
-          use: false
+f: !type:dict
+  var_1: !type:dict
+    a_config.ts.t4.use: false
     mode: training
-  var_2:
-    a_config:
-      ts:
-        t4:
-          use: true
-          fr: b
+  var_2: !type:dict
+    a_config.ts.t4.use: true
+    a_config.ts.t4.fr: b
     mode: validation
 mode: validation
 a_config:
@@ -46,7 +37,7 @@ a_config:
       - t3
       - t5
       - t4
-      sp: {}
+      sp: !type:dict {}
   v:
     s:
     - 320
@@ -56,7 +47,7 @@ a_config:
       - t1
       - t5
       - t4
-      sp:
+      sp: !type:dict
         t1.t1m: false
         t2.t1m: false
   te:
@@ -68,7 +59,7 @@ a_config:
       - t1
       - t5
       - t4
-      sp:
+      sp: !type:dict
         t1.t1m: false
         t2.t1m: false
   ts:
@@ -99,7 +90,7 @@ v:
   vf: 5
 c_config_file: c_config.yaml
 d_config_file: unittests/experiment/test_project_config/general/bsc
-tracker_config:
+tracker_config: !type:dict
   type:
   - basic
   - clearml

--- a/usage_example/configs/default/data_config.yaml
+++ b/usage_example/configs/default/data_config.yaml
@@ -2,12 +2,12 @@
 
 name: "My Gaussian Dataset"
 
-generation: !generation
+generation:
     mean: 0
     variance: 0.1
 
-train: !train  # adding this for reference, but no training set is actually used in this sample code
+train:  # adding this for reference, but no training set is actually used in this sample code
     size: 1
 
-test: !test
+test:
     size: 10000

--- a/yaecs/config/config.py
+++ b/yaecs/config/config.py
@@ -17,11 +17,10 @@ Copyright (C) 2022  Reactive Reality
 """
 
 import logging
-import sys
 import time
 from typing import Callable, Dict, List, Optional
 
-from ..yaecs_utils import ConfigInput, ConfigDeclarator, format_str, get_config_from_argv
+from ..yaecs_utils import ConfigInput, ConfigDeclarator, format_str, get_config_from_argv, is_config_in_argv
 from .config_base import _ConfigurationBase
 
 YAECS_LOGGER = logging.getLogger(__name__)
@@ -234,7 +233,7 @@ class Configuration(_ConfigurationBase):
                                overwriting_regime=overwriting_regime,
                                do_not_merge_command_line=do_not_merge_command_line,
                                do_not_pre_process=do_not_pre_process, do_not_post_process=do_not_post_process,
-                               from_argv=pattern if pattern in sys.argv else "", **kwargs)
+                               from_argv=pattern if is_config_in_argv(pattern=pattern) else "", **kwargs)
 
     def create_variations(self) -> List['Configuration']:
         """

--- a/yaecs/config/config_base.py
+++ b/yaecs/config/config_base.py
@@ -383,7 +383,7 @@ class _ConfigurationBase(ConfigHooksMixin, ConfigGettersMixin, ConfigSettersMixi
                     raise RuntimeError("Type-hinting is only allowed in the default config.")
                 name = yaml_loader.constructed_objects[list(yaml_loader.constructed_objects.keys())[-1]]
                 name = self._get_full_path(name)
-                methods = tag[6:]
+                methods = tag[len("!type:"):]
                 type_hint = methods
                 if all(method in self._assigned_as_yaml_tags for method in methods.split(",")):
                     lowest_priority = min(getattr(self._assigned_as_yaml_tags[method][0], "order", 0)

--- a/yaecs/config/config_setters.py
+++ b/yaecs/config/config_setters.py
@@ -96,7 +96,10 @@ class ConfigSettersMixin:
         :param name: full path of the param in the main config
         :param type_hint: type of the param
         """
-        self._type_hints[name] = type_hint
+        if self._are_same_sub_configs(self, self._main_config):
+            self._type_hints[name] = type_hint
+        else:
+            self._main_config.add_type_hint(self._get_full_path(name), type_hint)
 
     def set_sub_config(self, sub_config: 'Configuration') -> None:
         """

--- a/yaecs/config/yaml_scanner.py
+++ b/yaecs/config/yaml_scanner.py
@@ -1,0 +1,179 @@
+""" YAMLScanner class to pre-parse YAML files before feeding it to the config """
+
+import logging
+import re
+from typing import Any, Dict, Optional, Type
+
+import yaml
+
+from ..yaecs_utils import parse_type, YAML_EXPRESSIONS
+
+YAECS_LOGGER = logging.getLogger(__name__)
+
+
+class YAMLScanner:
+    """ YAMLScanner class to pre-parse YAML files before feeding it to the config """
+
+    def __init__(self, yaml_path: str):
+        self.path: str = yaml_path
+        self.params: Dict[str, Any] = {}
+        self.type_hints: Dict[str, str] = {}
+        self.processing_functions: Dict[str, str] = {}
+        self.state: Dict[str, Any] = {
+            "currently_processed_path": [],
+            "last_non_scalar": 0,
+            "sequence_depth": [],
+        }
+        with open(yaml_path, encoding='utf-8') as yaml_file:
+            list(yaml.load_all(yaml_file, Loader=self._get_yaml_loader()))
+
+    def resolve_node(self, yaml_loader, tag, node):
+        """ Resolve a YAML node to a Python object. """
+
+        with NoTag(yaml_loader):
+            if isinstance(node, yaml.ScalarNode):
+                if node.value == "":
+                    def _can_be_str(parsed_type):
+                        if parsed_type is str:
+                            return True
+                        if isinstance(parsed_type, tuple):
+                            if str in parsed_type:
+                                return True
+                            return any(_can_be_str(t) for t in parsed_type)
+                        return False
+                    if _can_be_str(parse_type(tag[len("!type:"):])):
+                        return yaml_loader.default_yaml_constructors["tag:yaml.org,2002:str"](yaml_loader, node)
+                for key, value in YAML_EXPRESSIONS.items():
+                    if value.match(node.value):
+                        return yaml_loader.default_yaml_constructors[f"tag:yaml.org,2002:{key}"](yaml_loader, node)
+                return yaml_loader.construct_scalar(node)
+            if isinstance(node, yaml.SequenceNode):
+                return yaml_loader.construct_sequence(node, deep=True)
+            if isinstance(node, yaml.MappingNode):
+                return yaml_loader.construct_mapping(node, deep=True)
+            raise ValueError(f"Unsupported node type {type(node)}.")
+
+    def update_state(self, yaml_loader, tag, node):
+        """ Updates the state of the scanner as it parses the YAML file. """
+
+        self.state["is_param_tag"] = bool(yaml_loader.constructed_objects) or tag.lower() == "!:no-tag:"
+        self.state["resolving_recursive_param"] = yaml_loader.DEFAULT_MAPPING_TAG == "!:no-tag:"
+        mapping_added = yaml_loader.constructed_objects and isinstance(
+            list(yaml_loader.constructed_objects.keys())[-1], yaml.MappingNode)
+        sequence_added = yaml_loader.constructed_objects and isinstance(
+            list(yaml_loader.constructed_objects.keys())[-1], yaml.SequenceNode)
+        node_type = "scalar" if isinstance(node, yaml.ScalarNode) else "sequence" if isinstance(
+            node, yaml.SequenceNode) else "mapping"
+
+        if node_type == "sequence":
+            self.state["sequence_depth"].append("sequence")
+        if sequence_added:
+            self.state["sequence_depth"].pop(-1)
+        if self.state["sequence_depth"]:
+            if node_type == "mapping":
+                self.state["sequence_depth"].append("mapping")
+            if mapping_added:
+                self.state["sequence_depth"].pop(-1)
+        if node_type == "mapping" or mapping_added or sequence_added:
+            self.state["last_non_scalar"] = len(yaml_loader.constructed_objects)
+
+        key_counter = len(yaml_loader.constructed_objects) - self.state["last_non_scalar"]
+        if self.state["sequence_depth"] and self.state["sequence_depth"][-1] == "sequence":
+            self.state["is_key_node"] = False
+        else:
+            self.state["is_key_node"] = node_type == "scalar" and self.state["is_param_tag"] and key_counter % 2 == 0
+
+    def _get_yaml_loader(self) -> Type[yaml.FullLoader]:
+        """ Used to get a custom YAML loader capable of parsing config tags. """
+
+        def generic_constructor(yaml_loader, tag, node):
+
+            self.update_state(yaml_loader, tag, node)
+
+            if self.state["is_key_node"]:
+                return yaml_loader.default_yaml_constructors["tag:yaml.org,2002:str"](yaml_loader, node)
+
+            if self.state["is_param_tag"]:
+                if self.state["resolving_recursive_param"]:
+                    return self.resolve_node(yaml_loader, tag, node)
+
+                name = yaml_loader.constructed_objects[list(yaml_loader.constructed_objects.keys())[-1]]
+                check_valid_param_name(name, f"Invalid name '{name}' found in file {self.path} : " + "{issue}.")
+                full_name = ".".join(self.state["currently_processed_path"] + [name])
+
+                if tag.lower() != "!type:config":
+                    if tag.lower().startswith("!type:"):
+                        self.type_hints[full_name] = tag[len("!type:"):]
+                    elif tag != "!:no-tag:" and not tag.startswith("tag:yaml.org,2002:"):
+                        self.processing_functions[full_name] = tag[1:].split(",")
+
+                    self.params[full_name] = self.resolve_node(yaml_loader, tag, node)
+                    return self.params[full_name]
+
+            else:
+                if tag.lower() == "!type:config":
+                    # If root of the YAML file but no provided name > assume dict
+                    return yaml_loader.construct_mapping(node, deep=True)
+                # If root of the YAML file and a name is provided > use first part as config name
+                name = tag[1:]
+                check_valid_param_name(name, f"Invalid name '{name}' found in file {self.path} : " + "{issue}.")
+
+            with InSubConfig(self, name):
+                value = yaml_loader.construct_mapping(node)
+
+            return value
+
+        loader = yaml.FullLoader
+        if not hasattr(loader, "default_yaml_constructors"):
+            loader.default_yaml_constructors = dict(loader.yaml_constructors)
+            loader.yaml_constructors = {}
+        loader.DEFAULT_MAPPING_TAG = "!type:config"
+        loader.DEFAULT_SCALAR_TAG = "!:no-tag:"
+        loader.DEFAULT_SEQUENCE_TAG = "!:no-tag:"
+        yaml.add_multi_constructor("", generic_constructor, Loader=loader)
+
+        return loader
+
+
+def check_valid_param_name(name: str, message: Optional[str] = None) -> None:
+    """ Raise relevant errors in the input name is not a valid sub-config name. """
+    issue = None
+    if not name:
+        issue = "sub-config names cannot be empty"
+    if not re.match(r'^[A-Za-z_*]', name):
+        issue = "sub-config names must start with a letter or an underscore"
+    if not re.match(r'^[A-Za-z0-9._*]*$', name):
+        issue = "sub-config names can only contain letters, numbers, dots and underscores"
+    if name.endswith('.'):
+        issue = "sub-config names cannot end with a dot"
+    if issue:
+        raise ValueError(message.format_map({"issue": issue}))
+
+
+class NoTag:
+    """ Context manager to temporarily set the default mapping of a loader to "!:no-tag:" """
+
+    def __init__(self, loader):
+        self.loader = loader
+        self.saved_default_mapping_tag = None
+
+    def __enter__(self):
+        self.saved_default_mapping_tag = self.loader.DEFAULT_MAPPING_TAG
+        self.loader.DEFAULT_MAPPING_TAG = "!:no-tag:"
+
+    def __exit__(self, *args):
+        self.loader.DEFAULT_MAPPING_TAG = self.saved_default_mapping_tag
+
+
+class InSubConfig:
+    """ Context manager to temporarily append a name to the currently processed path. """
+
+    def __init__(self, scanner, name):
+        self.scanner = scanner
+        self.name = name
+
+    def __enter__(self):
+        self.scanner.state["currently_processed_path"].append(self.name)
+
+    def __exit__(self, *args):
+        self.scanner.state["currently_processed_path"].pop(-1)

--- a/yaecs/experiment/loggers/logger_basic.py
+++ b/yaecs/experiment/loggers/logger_basic.py
@@ -5,7 +5,6 @@ from shutil import copyfile
 import sys
 import traceback
 from typing import Any, Optional, Union
-import warnings
 
 from mock import patch
 
@@ -86,23 +85,21 @@ class BasicLogger(Logger):
         output_path = os.path.join(image_path, f"{os.path.basename(name)}.{extension}")
 
         # Logging
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=UserWarning)
-            if isinstance(image, str):
-                if not os.path.isfile(image):
-                    raise FileNotFoundError(f"Cannot log image '{image}' : path does not exist !")
-                copyfile(image, output_path[:-len(extension)] + image.split(".")[-1])
-            elif isinstance(image, np.ndarray):
-                Image.fromarray(image.astype(np.uint8)).save(output_path)
-            elif isinstance(image, Image.Image):
-                image.save(output_path)
-            elif isinstance(image, matplotlib.figure.Figure):
-                image.savefig(output_path)
-            elif isinstance(image, plotly.graph_objs.Figure):
-                plotly.io.write_image(image, output_path)
-            else:
-                YAECS_LOGGER.warning(f"WARNING : image {name} at step {step} was not logged to sub_logger {sub_logger}"
-                                     f" : unrecognised type {type(image)}.")
+        if isinstance(image, str):
+            if not os.path.isfile(image):
+                raise FileNotFoundError(f"Cannot log image '{image}' : path does not exist !")
+            copyfile(image, output_path[:-len(extension)] + image.split(".")[-1])
+        elif isinstance(image, np.ndarray):
+            Image.fromarray(image.astype(np.uint8)).save(output_path)
+        elif isinstance(image, Image.Image):
+            image.save(output_path)
+        elif isinstance(image, matplotlib.figure.Figure):
+            image.savefig(output_path)
+        elif isinstance(image, plotly.graph_objs.Figure):
+            plotly.io.write_image(image, output_path)
+        else:
+            YAECS_LOGGER.warning(f"WARNING : image {name} at step {step} was not logged to sub_logger {sub_logger} : "
+                                 f"unrecognised type {type(image)}.")
 
 
 class BasicTrackerContext:

--- a/yaecs/experiment/loggers/logger_clearml.py
+++ b/yaecs/experiment/loggers/logger_clearml.py
@@ -3,7 +3,6 @@ import importlib.util
 import logging
 import os
 from typing import Any, Optional, Union
-import warnings
 
 from .base_logger import Logger
 from .logger_utils import NotImportedModule, value_to_float

--- a/yaecs/experiment/loggers/logger_clearml.py
+++ b/yaecs/experiment/loggers/logger_clearml.py
@@ -73,7 +73,7 @@ class ClearMLLogger(Logger):
     def log_scalar(self, name: str, value: Union[float, int], step: Optional[int] = None,
                    sub_logger: Optional[str] = None, description: Optional[str] = None) -> None:
         self._warn_function_argument("log_scalar", "description", description, None)
-        value = value_to_float(value, self.name)
+        value = value_to_float(value, self.name, name)
         if value == "":
             return
 
@@ -97,23 +97,21 @@ class ClearMLLogger(Logger):
         self._warn_function_argument("log_image", "extension", extension, "png")
         sub_logger = "logged_images" if sub_logger is None else sub_logger
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings('ignore', category=UserWarning)
-            if isinstance(image, str):
-                self.task.logger.report_image(title=sub_logger, series=name, local_path=image, iteration=step)
-            elif isinstance(image, np.ndarray):
-                self.task.logger.report_image(title=sub_logger, series=name, image=image.astype(np.uint8),
-                                              iteration=step)
-            elif isinstance(image, Image):
-                self.task.logger.report_image(title=sub_logger, series=name, image=np.array(image, dtype=np.uint8),
-                                              iteration=step)
-            elif isinstance(image, matplotlib.figure.Figure):
-                self.task.logger.report_matplotlib(title=sub_logger, series=name, iteration=step, figure=image)
-            elif isinstance(image, plotly.graph_objects.Figure):
-                self.task.logger.report_plotly(title=sub_logger, series=name, iteration=step, figure=image)
-            else:
-                self.task.logger.report_image(title=sub_logger, series=name, image=np.array(image, dtype=np.uint8),
-                                              iteration=step)
+        if isinstance(image, str):
+            self.task.logger.report_image(title=sub_logger, series=name, local_path=image, iteration=step)
+        elif isinstance(image, np.ndarray):
+            self.task.logger.report_image(title=sub_logger, series=name, image=image.astype(np.uint8),
+                                          iteration=step)
+        elif isinstance(image, Image):
+            self.task.logger.report_image(title=sub_logger, series=name, image=np.array(image, dtype=np.uint8),
+                                          iteration=step)
+        elif isinstance(image, matplotlib.figure.Figure):
+            self.task.logger.report_matplotlib(title=sub_logger, series=name, iteration=step, figure=image)
+        elif isinstance(image, plotly.graph_objects.Figure):
+            self.task.logger.report_plotly(title=sub_logger, series=name, iteration=step, figure=image)
+        else:
+            self.task.logger.report_image(title=sub_logger, series=name, image=np.array(image, dtype=np.uint8),
+                                          iteration=step)
 
     def _get_tast_type(self):
         """ Returns the task type for the ClearML task, inferred from the experiment mode if there is one. """

--- a/yaecs/experiment/loggers/logger_mlflow.py
+++ b/yaecs/experiment/loggers/logger_mlflow.py
@@ -47,7 +47,7 @@ class MLFlowLogger(Logger):
     def log_scalar(self, name: str, value: Union[float, int], step: Optional[int] = None,
                    sub_logger: Optional[str] = None, description: Optional[str] = None) -> None:
         self._warn_function_argument("log_scalar", "description", description, None)
-        value = value_to_float(value, self.name)
+        value = value_to_float(value, self.name, name)
         if value == "":
             return
 

--- a/yaecs/experiment/loggers/logger_sacred.py
+++ b/yaecs/experiment/loggers/logger_sacred.py
@@ -58,7 +58,7 @@ class SacredLogger(Logger):
     def log_scalar(self, name: str, value: Union[float, int], step: Optional[int] = None,
                    sub_logger: Optional[str] = None, description: Optional[str] = None) -> None:
         self._warn_function_argument("log_scalar", "description", description, None)
-        value = value_to_float(value, self.name)
+        value = value_to_float(value, self.name, name)
         if value == "":
             return
 

--- a/yaecs/experiment/loggers/logger_tensorboard.py
+++ b/yaecs/experiment/loggers/logger_tensorboard.py
@@ -44,7 +44,7 @@ class TensorBoardLogger(Logger):
 
     def log_scalar(self, name: str, value: Union[float, int], step: Optional[int] = None,
                    sub_logger: Optional[str] = None, description: Optional[str] = None) -> None:
-        value = value_to_float(value, self.name)
+        value = value_to_float(value, self.name, name)
         if value == "":
             return
 

--- a/yaecs/experiment/loggers/logger_utils.py
+++ b/yaecs/experiment/loggers/logger_utils.py
@@ -88,11 +88,14 @@ def new_print(*args, sep: str = " ", end: str = "", file: io.TextIOWrapper = Non
             logging.getLogger("yaecs.print_catcher").info(message)
 
 
-def value_to_float(value: Any, logger_name: str) -> str:
+def value_to_float(value: Any, logger_name: str, value_name: str) -> str:
     """ Converts a value to a float if possible, otherwise raises a warning and returns an empty string. """
     try:
         value = float(value)
     except ValueError:
-        YAECS_LOGGER.warning(f"WARNING : will not log non-float value {value} to {logger_name} logger.")
+        YAECS_LOGGER.warning(f"WARNING : will not log non-float value '{value_name}': {value} to {logger_name} logger.")
         return ""
+    if not isinstance(value, (float, int)):
+        YAECS_LOGGER.warning(f"WARNING : logging non-float value '{value_name}': {value} to {logger_name} logger.\name"
+                             "Logging non-float values can cause unexpected time or space complexity in some loggers.")
     return value

--- a/yaecs/experiment/loggers/logger_utils.py
+++ b/yaecs/experiment/loggers/logger_utils.py
@@ -23,7 +23,7 @@ class NotImportedModule:
         if item == "_NotImportedModule__name":
             return object.__getattribute__(self, item)
         raise ModuleNotFoundError(f"Module {self.__name} is not installed. If you want to use this feature, please "
-                                  "install it..")
+                                  "install it.")
 
 
 def add_to_csv(csv_path: str, name: str, value: Any, step: int) -> None:

--- a/yaecs/user_utils.py
+++ b/yaecs/user_utils.py
@@ -16,11 +16,10 @@ Copyright (C) 2022  Reactive Reality
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 import logging
-import sys
 from typing import Callable, Dict, List, Optional, Type, Union
 
 from .config.config import Configuration
-from .yaecs_utils import ConfigInput, ConfigDeclarator, TqdmLogger, get_config_from_argv
+from .yaecs_utils import ConfigInput, ConfigDeclarator, TqdmLogger, get_config_from_argv, is_config_in_argv
 
 YAECS_LOGGER = logging.getLogger(__name__)
 
@@ -179,7 +178,7 @@ def make_config(*configs: Union[ConfigDeclarator, List[ConfigDeclarator]],
 
     # Get configs from argv
     configs_from_argv = get_config_from_argv(pattern=pattern, fallback={} if fallback == "{}" else fallback)
-    class_building_kwargs["from_argv"] = pattern if pattern in sys.argv else ""
+    class_building_kwargs["from_argv"] = pattern if is_config_in_argv(pattern=pattern) else ""
     if all(c == {} for c in configs_from_argv):
         configs_from_argv = []
         class_building_kwargs["from_argv"] = ""

--- a/yaecs/yaecs_utils.py
+++ b/yaecs/yaecs_utils.py
@@ -304,10 +304,8 @@ def get_config_from_argv(pattern: str, fallback: Optional[ConfigInput] = None) -
     """
     pattern_index = None
     for index, element in enumerate(sys.argv):
-        if element.split("=", 1) == pattern:
+        if element.split("=", 1)[0] == pattern:
             pattern_index = index
-    if pattern_index is None and fallback is None:
-        raise TypeError(f"The pattern '{pattern}' was not detected in sys.argv.")
     if pattern_index is not None:
         # Aggregate all CLI chunks until the next flag
         configs = []
@@ -318,6 +316,8 @@ def get_config_from_argv(pattern: str, fallback: Optional[ConfigInput] = None) -
                 break
             configs.append(element)
         fallback = [cfg.strip(" ") for cfg in " ".join(configs).strip().strip("[]").split(",")]
+    if fallback is None:
+        raise TypeError(f"The pattern '{pattern}' was not detected in sys.argv.")
     if not isinstance(fallback, list):
         fallback = [fallback]
     return [cfg for cfg in fallback if cfg]
@@ -448,6 +448,20 @@ def is_type_valid(value: Any, config_class: type) -> bool:
     if isinstance(value, (Mapping, config_class)):
         return all(is_type_valid(i, config_class) for i in value.values())
     return isinstance(value, (int, float, str)) or value is None
+
+
+def is_config_in_argv(pattern: str) -> bool:
+    """
+    Returns True if the pattern is found in sys.argv.
+
+    :param pattern: pattern to detect in sys.argv
+    :return: result of the test
+    """
+    try:
+        _ = get_config_from_argv(pattern)
+        return True
+    except TypeError:
+        return False
 
 
 def parse_type(string_to_process: str) -> TypeHint:


### PR DESCRIPTION
- Disentangle the reading of YAML files from the Configuration object
- Make it so using config names as yaml tags in any case other than document tags is now deprecated
- Make it so using the !type:<processing function name> was replaced by !<processing function name>. Now, !type:<foo> is reserved for type hinting. !type:<processing function name> will still work until the next release, but will print a warning
- Solve various bugs and perform minor code improvements