### PR TITLE
Make sure post-processing does not overwrite its own changes.

### DIFF
--- a/yaecs/config/config_base.py
+++ b/yaecs/config/config_base.py
@@ -495,7 +495,8 @@ class _ConfigurationBase(ConfigHooksMixin, ConfigGettersMixin, ConfigSettersMixi
                  for s in splits}
         values = {name: self._main_config[name] for name in names}
 
-        self.get_setter()(names=names, values=values, processing_type="post", container=self)
+        self.get_setter()(names=names, values=values, processing_type="post", container=self,
+                          only_set_processed_parameters=True)
         for name in names:
             try:
                 should_save = values[name] != self._main_config[name]


### PR DESCRIPTION
In practice, when using the Setter to post-process, will only set values when a processor is actually used.