### PR TITLE
Add param print_slower_than to Tracker.step

### DIFF
--- a/yaecs/experiment/timer.py
+++ b/yaecs/experiment/timer.py
@@ -435,7 +435,7 @@ class TimerManager:
         return matches
 
     def render(self, which_step: Union[int, str] = "last", which_timer: Union[None, str, List[str]] = None,
-               verbose: Optional[int] = None) -> str:
+               slower_than: Optional[float] = None, verbose: Optional[int] = None) -> str:
         """
         Renders a string to display some properties of the timers.
 
@@ -444,13 +444,16 @@ class TimerManager:
             'average' (average of all recorded steps) or 'total' (sum of all recorded steps)
         :param which_timer: which timers to render. Can be None (by default, means all of them), or a timer name or list
             thereof which may contain wildcards ('*')
+        :param slower_than: if not None, only renders timers whose duration is greater than this value (in seconds)
         :param verbose: verbosity level. 0 is minimal, 1 is normal, 2 is high detail. If None, uses each timer's verbose
         :return: the rendered string
         """
         rendered_string = ""
         which_step = self._process_which(which_step)
         which_timer = self.get_timer_names(timer=which_timer)
-        durations = {name: duration for name, duration in self[which_step].items() if name in which_timer}
+        durations = {name: duration for name, duration in self[which_step].items()
+                     if name in which_timer and (slower_than is None or
+                                                 (duration is not None and duration > slower_than))}
         verbose = self.verbose if verbose is None else verbose
 
         # Set header

--- a/yaecs/experiment/tracker.py
+++ b/yaecs/experiment/tracker.py
@@ -161,13 +161,15 @@ class Tracker:
             params_to_log[pattern] = config.get_pre_post_processing_values().get(param_name, config[param_name])
         self.loggers.start_run(experiment_name, run_name, description, params_to_log)
 
-    def step(self, step: Optional[int] = None, auto_log_timers: bool = True, print_timers: bool = True) -> int:
+    def step(self, step: Optional[int] = None, auto_log_timers: bool = True, print_timers: bool = True,
+             print_slower_than: Optional[float] = None) -> int:
         """
         Increments the step counter.
 
         :param step: step to increment to. If None, will increment to the next step
         :param auto_log_timers: whether to automatically log the timers at the end of the step
         :param print_timers: whether to print the timers at the end of the step
+        :param print_slower_than: if provided, only prints timers whose average duration is above the given threshold
         """
         if step is not None and step < self._step:
             raise ValueError(f"Cannot go back to step {step} from step {self._step}.")
@@ -175,7 +177,7 @@ class Tracker:
             if auto_log_timers:
                 self.log_timer(name="timers/")
             if print_timers:
-                print(self.timer.render(which_step=self._step))
+                print(self.timer.render(which_step=self._step, slower_than=print_slower_than))
         self._step = (self._step + 1) if step is None else step
         return self._step
 


### PR DESCRIPTION
Add param print_slower_than to Tracker.step method to control which timers to print. Will only print timers if they took too long.